### PR TITLE
Allow for multiple devices.

### DIFF
--- a/aioeagle/hub.py
+++ b/aioeagle/hub.py
@@ -69,9 +69,9 @@ class EagleHub:
         result = []
 
         for device in xmltodict_ensure_list(response["DeviceList"], "Device"):
-            if device["ModelId"] == "electric_meter":
+            if device["ConnectionStatus"] == "Connected" and device["ModelId"] == "electric_meter":
                 result.append(ElectricMeter(device, self.make_request))
             else:
-                _LOGGER.debug(f"Skipping unknown device {device['ModelId']}")
+                _LOGGER.debug(f"Skipping unconnected or unknown device {device['ModelId']}")
 
         return result


### PR DESCRIPTION
When an electricity meter is replaced, a situation arises where the Eagle200 returns multiple devices.  The first device is not in connected state, but the second device is.  Consequently, HA shows the values as unavailable.

Proposed change adds a check for the connection status.

See [discussion](https://community.home-assistant.io/t/custom-component-rainforest-eagle-200-local-meter-reader/110656/113).